### PR TITLE
Fix working directory lookup

### DIFF
--- a/core/src/main/scala/com/lightbend/benchdb/Main.scala
+++ b/core/src/main/scala/com/lightbend/benchdb/Main.scala
@@ -29,7 +29,7 @@ object Main extends Logging {
     val showMetaCommand = Command[GlobalOptions => Unit](name = "show-meta", header =
       """Show the meta data for a project without storing it.
         |Use the current directory if no project-dir is specified.""".stripMargin, helpFlag = false) {
-      val projectDir = Opts.argument[Path](metavar = "project-dir").withDefault(FileSystems.getDefault.getPath(""))
+      val projectDir = Opts.argument[Path](metavar = "project-dir").withDefault(FileSystems.getDefault.getPath("").toAbsolutePath)
       projectDir.map { path => showMeta(_, path) }
     }
 


### PR DESCRIPTION
Java is unforgiving:

```
scala> FileSystems.getDefault.getPath("").toFile.list()
val res11: Array[String] = null

scala> FileSystems.getDefault.getPath("").toFile.getAbsoluteFile.list()
val res12: Array[String] = Array(core, LICENSE, target, plugin, README.md, project, .gitignore, benchdb, .git, .travis.yml, build.sbt, .idea)

```